### PR TITLE
bundler-fix and defer callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.2
+
+- Adding the "browser" build in package.json
+- Defer the triggerOnSetup-call to after the function is setup, to make sure the remove-callback is available inside it
+
 # 2.0.1
 
 - Made sure the default state for setupStateAwareInterval is "active"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "webapp-state",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A utility with sugar on top of the low-level online/offline events and the Page Visibility API",
+  "browser": "./dist/index.js",
   "main": "./dist/index.js",
   "module": "./src/index.js",
   "jsnext:main": "./src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ function setupEventListener(type, callback, options = { triggerOnSetup: false, o
 	};
 
 	if (options.triggerOnSetup) {
-		callback(getState(type));
+		setTimeout(() => callback(getState(type)), 1);
 	}
 
 	if (type === 'visibility') {
@@ -125,7 +125,7 @@ function setupStateAwareInterval(callback, timeout, options = { triggerOnSetup: 
 	const state = options.state || 'active';
 	const setupInterval = () => {
 		if (options.triggerOnSetup) {
-			callback();
+			setTimeout(callback, 1);
 		}
 		return setInterval(callback, timeout);
 	};


### PR DESCRIPTION
- Adding the "browser" build in package.json
- Defer the triggerOnSetup-call to after the function is setup, to make sure the remove-callback is available inside it
- Version update